### PR TITLE
Add/improve support for mac addresses; cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ The `Nerves.NetworkInterface` application will start automatically.
 To see which interfaces are available, call `Nerves.NetworkInterface.interfaces\0`:
 
     iex> Nerves.NetworkInterface.interfaces
-	['lo', 'eth0', 'wlan0']
+    ["lo", "eth0", "wlan0"]
 
 To get link-level status information and statistics on an interface, call
 `Nerves.NetworkInterface.status/1`:
 
     iex> Nerves.NetworkInterface.status "eth0"
-    {:ok, %{ifname: 'eth0', index: 2, is_broadcast: true, is_lower_up: true,
+    {:ok, %{ifname: "eth0", index: 2, is_broadcast: true, is_lower_up: true,
             is_multicast: true, is_running: true, is_up: true,
-            mac_address: <<224, 219, 85, 231, 139, 93>>,
-            mac_broadcast: <<255, 255, 255, 255, 255, 255>>, mtu: 1500, operstate: :up,
+            mac_address: "e0:db:55:e7:8b:53",
+            mac_broadcast: "ff:ff:ff:ff:ff:ff", mtu: 1500, operstate: :up,
             stats: %{collisions: 0, multicast: 7, rx_bytes: 2561254, rx_dropped: 0,
               rx_errors: 0, rx_packets: 5301, tx_bytes: 944159, tx_dropped: 0,
               tx_errors: 0, tx_packets: 3898}, type: :ethernet}
@@ -118,10 +118,10 @@ The following example shows how to view events at the prompt:
     # Plug Ethernet cable in
     iex> flush()
     {Nerves.NetworkInterface, :ifchanged,
-     %{ifname: 'eth0', index: 2, is_broadcast: true, is_lower_up: true,
+     %{ifname: "eth0", index: 2, is_broadcast: true, is_lower_up: true,
        is_multicast: true, is_running: true, is_up: true,
-       mac_address: <<224, 219, 85, 231, 139, 93>>,
-       mac_broadcast: <<255, 255, 255, 255, 255, 255>>, mtu: 1500, operstate: :up,
+       mac_address: "e0:db:55:e7:8b:53",
+       mac_broadcast: "ff:ff:ff:ff:ff:ff", mtu: 1500, operstate: :up,
        stats: %{collisions: 0, multicast: 14, rx_bytes: 3061718, rx_dropped: 0,
          rx_errors: 0, rx_packets: 7802, tx_bytes: 1273557, tx_dropped: 0,
          tx_errors: 0, tx_packets: 5068}, type: :ethernet}}

--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ Events sent by `Nerves.NetworkInterface` include:
 To get the IP configuration for an interface, call `Nerves.NetworkInterface.settings/1`:
 
     iex> Nerves.NetworkInterface.settings "eth0"
-    {:ok, %{ipv4_address: '192.168.25.114', ipv4_broadcast: '192.168.25.255',
-            ipv4_gateway: '192.168.25.5', ipv4_subnet_mask: '255.255.255.0'}
+    {:ok, %{ipv4_address: "192.168.25.114", ipv4_broadcast: "192.168.25.255",
+            ipv4_gateway: "192.168.25.5", ipv4_subnet_mask: "255.255.255.0",
+            mac_address: "e0:db:55:e7:8b:51"}
 
 To setting IP addresses and other configuration, just call
 `Nerves.NetworkInterface.setup/2` using keyword parameters or a map with what you'd like

--- a/README.md
+++ b/README.md
@@ -54,13 +54,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
           [{:nerves_network_interface, "~> 0.3.2"}]
         end
 
-  2. List `:nerves_network_interface` as an application dependency:
-
-        def application do
-          [applications: [:nerves_network_interface]]
-        end
-
-  3. Run `mix deps.get` and `mix compile`
+  2. Run `mix deps.get` and `mix compile`
 
 ## Permissions
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Nerves.NetworkInterface.Mixfile do
   end
 
   defp deps do
-    [{:elixir_make, "~> 0.3", runtime: false},
+    [{:elixir_make, "~> 0.4", runtime: false},
      {:ex_doc, "~> 0.11", only: :dev}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
-  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{"earmark": {:hex, :earmark, "1.2.1", "7ad3f203ab84d31832814483c834e006cf88949f061a4b50d7e783147572280f", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}

--- a/src/erlcmd.c
+++ b/src/erlcmd.c
@@ -250,6 +250,7 @@ int erlcmd_encode_errno_error(char *buf, int *index, int err)
     case EROFS:   reason = "erofs"; break;
     case EMLINK:  reason = "emlink"; break;
     case EPIPE:   reason = "epipe"; break;
+    case EADDRNOTAVAIL: reason = "eaddrnotavail"; break;
     default:      reason = "unknown"; break;
     }
     return erlcmd_encode_error_tuple(buf, index, reason);

--- a/src/netif.c
+++ b/src/netif.c
@@ -38,6 +38,8 @@
 // 0x10000.
 #define WORKAROUND_IFF_LOWER_UP (0x10000)
 
+#define MACADDR_STR_LEN      18 // aa:bb:cc:dd:ee:ff and a null terminator
+
 #include "erlcmd.h"
 
 //#define DEBUG
@@ -583,6 +585,9 @@ struct ip_setting_handler {
     int ioctl_get;
 };
 
+static int prep_mac_address_ioctl(const struct ip_setting_handler *handler, struct netif *nb, void **context);
+static int set_mac_address_ioctl(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname, void *context);
+static int get_mac_address_ioctl(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname);
 static int prep_ipaddr_ioctl(const struct ip_setting_handler *handler, struct netif *nb, void **context);
 static int set_ipaddr_ioctl(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname, void *context);
 static int get_ipaddr_ioctl(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname);
@@ -598,9 +603,84 @@ static const struct ip_setting_handler handlers[] = {
     { "ipv4_address", prep_ipaddr_ioctl, set_ipaddr_ioctl, get_ipaddr_ioctl, SIOCSIFADDR, SIOCGIFADDR },
     { "ipv4_subnet_mask", prep_ipaddr_ioctl, set_ipaddr_ioctl, get_ipaddr_ioctl, SIOCSIFNETMASK, SIOCGIFNETMASK },
     { "ipv4_broadcast", prep_ipaddr_ioctl, set_ipaddr_ioctl, get_ipaddr_ioctl, SIOCSIFBRDADDR, SIOCGIFBRDADDR },
-    { "ipv4_gateway", prep_default_gateway, set_default_gateway, get_default_gateway, 0, 0 }
+    { "ipv4_gateway", prep_default_gateway, set_default_gateway, get_default_gateway, 0, 0 },
+    { "mac_address", prep_mac_address_ioctl, set_mac_address_ioctl, get_mac_address_ioctl, SIOCSIFHWADDR, SIOCGIFHWADDR },
 };
 #define HANDLER_COUNT (sizeof(handlers) / sizeof(handlers[0]))
+
+static int prep_mac_address_ioctl(const struct ip_setting_handler *handler, struct netif *nb, void **context)
+{
+    char macaddr[MACADDR_STR_LEN];
+    if (erlcmd_decode_string(nb->req, &nb->req_index, macaddr, sizeof(macaddr)) < 0)
+        errx(EXIT_FAILURE, "mac address parameter required for '%s'", handler->name);
+
+    // Be forgiving and if the user specifies an empty IP address, just skip
+    // this request.
+    if (macaddr[0] == '\0')
+        *context = NULL;
+    else
+        *context = strdup(macaddr);
+
+    return 0;
+}
+
+static int set_mac_address_ioctl(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname, void *context)
+{
+    const char *macaddr = (const char *) context;
+
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+
+    struct sockaddr_in *addr = (struct sockaddr_in *) &ifr.ifr_addr;
+    addr->sin_family = AF_UNIX;
+    unsigned char *mac = (unsigned char *) &ifr.ifr_hwaddr.sa_data;
+    if (sscanf(macaddr,
+               "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
+               &mac[0], &mac[1], &mac[2],
+               &mac[3], &mac[4], &mac[5]) != 6) {
+        debug("Bad MAC address for '%s': %s", handler->name, macaddr);
+        nb->last_error = EINVAL;
+        return -1;
+    }
+
+    if (ioctl(nb->inet_fd, handler->ioctl_set, &ifr) < 0) {
+        debug("ioctl(0x%04x) failed for setting '%s': %s", handler->ioctl_set, handler->name, strerror(errno));
+        nb->last_error = errno;
+        return -1;
+    }
+
+    return 0;
+}
+
+static int get_mac_address_ioctl(const struct ip_setting_handler *handler, struct netif *nb, const char *ifname)
+{
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+
+    if (ioctl(nb->inet_fd, handler->ioctl_get, &ifr) < 0) {
+        debug("ioctl(0x%04x) failed for getting '%s': %s", handler->ioctl_get, handler->name, strerror(errno));
+        nb->last_error = errno;
+        return -1;
+    }
+
+    struct sockaddr_in *addr = (struct sockaddr_in *) &ifr.ifr_addr;
+    if (addr->sin_family == AF_UNIX) {
+        char macaddr[MACADDR_STR_LEN];
+        unsigned char *mac = (unsigned char *) &ifr.ifr_hwaddr.sa_data;
+        snprintf(macaddr, sizeof(macaddr),
+                 "%02x:%02x:%02x:%02x:%02x:%02x",
+                 mac[0], mac[1], mac[2],
+                 mac[3], mac[4], mac[5]);
+        encode_kv_string(nb, handler->name, macaddr);
+    } else {
+        debug("got unexpected sin_family %d for '%s'", addr->sin_family, handler->name);
+        nb->last_error = EINVAL;
+        return -1;
+    }
+    return 0;
+}
 
 static int prep_ipaddr_ioctl(const struct ip_setting_handler *handler, struct netif *nb, void **context)
 {
@@ -650,9 +730,9 @@ static int get_ipaddr_ioctl(const struct ip_setting_handler *handler, struct net
     strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
 
     if (ioctl(nb->inet_fd, handler->ioctl_get, &ifr) < 0) {
-        debug("ioctl(0x%04x) failed for getting '%s': %s", handler->ioctl_get, handler->name, strerror(errno));
-        nb->last_error = errno;
-        return -1;
+        debug("ioctl(0x%04x) failed for getting '%s': %s. Skipping...", handler->ioctl_get, handler->name, strerror(errno));
+        encode_kv_string(nb, handler->name, "");
+        return 0;
     }
 
     struct sockaddr_in *addr = (struct sockaddr_in *) &ifr.ifr_addr;


### PR DESCRIPTION
This PR primarily adds support for setting the mac address for an interface. This is required for the BBGW which has a wireless module that needs its mac address programmed at boot. It also changes some existing mac address code to use string "aa:bb:cc:dd:ee:ff" formatted addresses, since that's the common way of formatting them.

Several other cleanup changes were also done.