### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables to override
 #
-# CC            C compiler
+# CC            C compiler. MUST be set if crosscompiling
 # CROSSCOMPILE	crosscompiler prefix, if any
 # CFLAGS        compiler flags for compiling all C files
 # ERL_PATH      the path to the erlang installation (e.g., /usr/lib/erlang)
@@ -38,7 +38,6 @@ ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR) -lei
 LDFLAGS += -lmnl
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 
-CC ?= $(CROSSCOMPILE)-gcc
 
 # Unfortunately, depending on the system we're on, we need
 # to specify -std=c99 or -std=gnu99. The later is more correct,

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,9 @@ CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 # Unfortunately, depending on the system we're on, we need
 # to specify -std=c99 or -std=gnu99. The later is more correct,
 # but it fails to build on many setups.
-ifeq ($(shell CC=$(CC) src/test-c99.sh),yes)
+# NOTE: Need to call sh here since file permissions are not preserved
+#       in hex packages.
+ifeq ($(shell CC=$(CC) sh src/test-c99.sh),yes)
 CFLAGS += -std=c99 -D_XOPEN_SOURCE=600
 else
 CFLAGS += -std=gnu99


### PR DESCRIPTION
These need to be propagated to all Nerves projects, but I'm starting here. The first commit cleans up misleading code where it looked as if you could set CROSSCOMPILE and the crosscompiler was guaranteed to run. That turned out never to be the case, but Nerves never relied on it. The second commit works around execute permissions not being preserved in hex packages. It doesn't appear to have broken a build yet, but it's an ugly error that you get and people will wonder. I would presume that it's been happening for a long time now.