### PR TITLE
Improve compiler flag test

### DIFF
--- a/src/test-c99.sh
+++ b/src/test-c99.sh
@@ -5,5 +5,31 @@ if [ -z $CC ]; then
 fi
 
 # See Makefile
-printf '#include <arpa/inet.h>\n#include <net/if.h>\n#include <linux/if.h>\nint main(int argc,char*argv[]) { return IFF_UP; }' | $CC -std=c99 -D_XOPEN_SOURCE=600 -o /dev/null -xc - 2>/dev/null && printf "yes"
+$CC -std=c99 -D_XOPEN_SOURCE=600 -o /dev/null -xc - 2>/dev/null <<EOF
+// For whatever reason, this test is more robust when the include
+// order matches what's in netif.c
+#include <err.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <arpa/inet.h>
+#include <libmnl/libmnl.h>
+#include <net/if_arp.h>
+#include <net/if.h>
+#include <net/route.h>
+#include <linux/if.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+int main(int argc,char *argv[]) {
+    return IFF_UP;
+}
+EOF
+if [ "$?" = "0" ]; then
+    printf "yes"
+fi
 


### PR DESCRIPTION
The nerves_system_vultr musl build had different results depending on
whether the include files for one way or the other. This matches the
includes with the actual source code, so there shouldn't be a mismatch.
This is either a Linux kernel header file issue or a musl one. It seems
like a Linux kernel header file one since nerves_system_x86_64/musl
didn't have the same issue and it has a new Linux kernel.