### PR TITLE
Sync dialyxir and ex_doc deps with other projects

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,8 +39,8 @@ defmodule Nerves.NetworkInterface.Mixfile do
   end
 
   defp deps do
-    [{:dialyxir,    ">= 0.0.0", only: [:dev, :test]},
+    [{:dialyxir,    ">= 0.5.1", only: [:dev, :test], runtime: false},
      {:elixir_make, "~> 0.4", runtime: false},
-     {:ex_doc, "~> 0.11", only: :dev}]
+     {:ex_doc, "~> 0.18.0", only: [:dev, :test], runtime: false}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.4.1", "6628b86053190a80b9072382bb9756a6c78624f208ec0ff22cb94c8977d80060", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
 }


### PR DESCRIPTION
Both Dialyxir and ex_doc were included at runtime. This additionally
synchronizes how we specify the deps on other projects.